### PR TITLE
Sections in `pepsflow.cfg` and additional `Niter` option

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1067,6 +1067,26 @@ pygments = ">=2.13.0,<3.0.0"
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "rich-click"
+version = "1.8.5"
+description = "Format click help output nicely with rich"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "rich_click-1.8.5-py3-none-any.whl", hash = "sha256:0fab7bb5b66c15da17c210b4104277cd45f3653a7322e0098820a169880baee0"},
+    {file = "rich_click-1.8.5.tar.gz", hash = "sha256:a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1"},
+]
+
+[package.dependencies]
+click = ">=7"
+rich = ">=10.7"
+typing_extensions = ">=4"
+
+[package.extras]
+dev = ["mypy", "packaging", "pre-commit", "pytest", "pytest-cov", "rich-codex", "ruff", "types-setuptools"]
+docs = ["markdown_include", "mkdocs", "mkdocs-glightbox", "mkdocs-material-extensions", "mkdocs-material[imaging] (>=9.5.18,<9.6.0)", "mkdocs-rss-plugin", "mkdocstrings[python]", "rich-codex"]
+
+[[package]]
 name = "scienceplots"
 version = "2.1.1"
 description = "Format Matplotlib for scientific plotting"
@@ -1266,4 +1286,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "713801a128202ededf282ace6fe15e945dab266bb84cb76d4e83ffadf02862d0"
+content-hash = "1344e31265003af96dda6f1270e577233b4e348cbfeb82fcdaf2f58b967baa03"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ rich = "^13.9.2"
 opt-einsum = "^3.4.0"
 pytorch-minimize = "^0.0.2"
 ncg-optimizer = "^0.1.1"
+rich-click = "^1.8.5"
 
 [tool.poetry.scripts]
 pepsflow = "pepsflow.cli.main:cli"

--- a/src/pepsflow/cli/main.py
+++ b/src/pepsflow/cli/main.py
@@ -1,4 +1,4 @@
-import click
+import rich_click as click
 
 from pepsflow.cli.data import data
 from pepsflow.cli.params import params
@@ -6,6 +6,10 @@ from pepsflow.cli.params import params
 
 @click.group()
 def cli():
+    """
+    pepsflow is a tool to optimize Projected Entangled Pair States (PEPS) using the Corner Transfer Matrix
+    Renormalization Group (CTMRG) algorithm and automatic differentiation.
+    """
     pass
 
 

--- a/src/pepsflow/cli/params.py
+++ b/src/pepsflow/cli/params.py
@@ -1,8 +1,9 @@
-import click
+import rich_click as click
 import configparser
 from rich.console import Console
 from rich.table import Table
 from rich import box
+import ast
 
 import pepsflow.pepsflow as pepsflow
 
@@ -16,7 +17,7 @@ def params(ctx):
     """
     if ctx.invoked_subcommand is None:
         config = configparser.ConfigParser()
-        config.optionxform = str # Preserve the case of the keys
+        config.optionxform = lambda option: option # Preserve case
         config.read("src/pepsflow/pepsflow.cfg")
         console = Console()
         table = Table(title="PEPSFLOW parameters", title_justify="center", box=box.SIMPLE)
@@ -33,13 +34,13 @@ def params(ctx):
 
 
 @params.command()
+@click.option("-N","--Niter","Niter", type=int, help="Number of iterations in the forward step.")
+@click.option("--D", "D", type=str, help="One value or comma separated list of values of the bulk dimension d of the iPEPS tensor.")
 @click.option("--model", type=str, help="Model to optimize. Options are 'Ising' and 'Heisenberg'.")
 @click.option("--chi", type=str, help="One value of comma separated list of values of the bond dimension chi of the CTM algorithm.")
-@click.option("--D", type=str, help="One value or comma separated list of values of the bulk dimension d of the iPEPS tensor.")
 @click.option("-r","--read", type=str, help="Folder containing iPEPS models and other datafiles to read.")
 @click.option("--gpu/--no-gpu", default=None, type=bool, help="Run the model on the GPU if available.")
 @click.option("--lam", type=str, help="One value of comma separated list of values of the parameter lambda in the tranverse-field Ising model.")
-@click.option("-N","--Niter", type=int, help="Number of iterations in the forward step.")
 @click.option("-lr","--learning_rate", type=str, help="One value or comma separated list of values of the learning rate for the optimizer.")
 @click.option("--epochs", type=int, help="Maximum number of epochs to train the model.")
 @click.option("-per", "--perturbation", type=float, help="Amount of perturbation to apply to the initial state.")
@@ -51,37 +52,23 @@ def params(ctx):
 @click.option("--split/--no-split", default = None, type=bool, help="Keep the tensor in the CTM algorithm split or not.")
 @click.option("-o", "--optimizer", type=str, help="Optimizer to use. Options are 'adam' and 'lbfgs'.")
 @click.option("--seed", type=float, help="Seed for the random generation of tensors.")
-def set(**args):
+def set(Niter: int, D: int, **args):
     """
     Set specific parameters for the optimization of the iPEPS tensor network.
     """
+    args['Niter'], args['D'] = Niter, D # For case preservation.
     config = configparser.ConfigParser()
-    config.optionxform = str
+    config.optionxform = lambda option: option
     file = "src/pepsflow/pepsflow.cfg"
     config.read(file)
 
     for section in config.sections():
         for param, value in args.items():
-            if param == 'd': param = 'D'
-            if param == 'niter': param = 'Niter'
-
             if param in config[section] and value is not None:
-
-                # Varying parameters
+                
+                # Convert to list if comma separated values
                 if type(value) == str and ',' in value:
-                    match param:
-                        case 'chi': 
-                            list_type = int
-                        case 'D':
-                            list_type = int
-                        case 'lam':
-                            list_type = float
-                        case 'learning_rate':
-                            list_type = float
-                        case 'optimizer':
-                            list_type = str
-                        
-                    value = [list_type(x) for x in value.split(",") if x]
+                    value = [ast.literal_eval(x) for x in value.split(",") if x]
 
                 config[section][param] = str(value)
 

--- a/src/pepsflow/iPEPS/converger.py
+++ b/src/pepsflow/iPEPS/converger.py
@@ -1,9 +1,5 @@
-from pepsflow.models.CTM_alg import CtmAlg
-from pepsflow.models.tensors import Tensors
-from pepsflow.models.observables import Observables
 from pepsflow.iPEPS.iPEPS import iPEPS
 
-import json
 import torch
 import os
 from rich.progress import Progress, TextColumn, BarColumn, MofNCompleteColumn, TimeElapsedColumn
@@ -15,13 +11,12 @@ class Converger:
     Class to compute the converged energies of a PEPS state for different values of chi.
 
     Args:
-        args (dict): Dictionary containing the arguments of the iPEPS model.
+        ipeps (iPEPS): iPEPS model to compute the energies for.
+        args (dict): Dictionary containing the iPEPS parameters.
     """
 
-    def __init__(self, args: dict):
-        self.data: iPEPS = None
-        self.energies = []
-        self.args = args
+    def __init__(self, ipeps: iPEPS, args: dict):
+        self.ipeps = iPEPS(args, ipeps)
 
         self.progress = Progress(
             TextColumn("[progress.description]{task.description}"),
@@ -32,65 +27,32 @@ class Converger:
             TimeElapsedColumn(),
         )
         self.task = self.progress.add_task(
-            f"[blue bold]CTM steps (χ = {args['chi']})", total=args["warmup_steps"], start=False
+            f"[blue bold]CTM steps (χ = {args['chi']})", total=args["Niter"], start=False
         )
-
-    def read(self, fn: str):
-        """
-        Read the data from a torch .pth file.
-
-        Args:
-            fn (str): Filename to read the data from, without file extension. Has to be a .pth file.
-        """
-        self.data: iPEPS = torch.load(fn, weights_only=False)
 
     def exe(self):
         """
         Compute the energy if a converged iPEPS state for a given bond dimension using the CTMRG
         algorithm. This method can only be called after reading the data.
         """
-        if self.data is None:
-            raise ValueError("No data found. Please first read data.")
+        Niter = self.ipeps.args["Niter"]
+        self.ipeps.args["Niter"] = 1
+        with self.progress:
+            for _ in range(Niter):
+                E, C, T = self.ipeps.forward()
+                self.ipeps.add_data(E, C, T)
+                self.progress.update(self.task, advance=1)
 
-        else:
-            A = self.data.params[self.data.map]
-            H = (
-                Tensors.H_Ising(self.args["lam"])
-                if self.args["model"] == "Ising"
-                else Tensors.H_Heisenberg(self.args["lam"])
-            )
-
-            with self.progress:
-                alg = CtmAlg(A, self.args["chi"], split=self.args["split"])
-                for _ in range(self.args["warmup_steps"]):
-                    alg.exe(1, self.progress, self.task)
-                    self.energies.append(Observables.E(A, H, alg.C, alg.T).item())
-
-    def write(self, fn: str):
+    def write(self, fn: str) -> None:
         """
-        Save the energies to a JSON file.
+        Save the collected data to a torch .pth file.
 
         Args:
-            fn (str): Filename to save the data. This filename will be appended with '.json'.
+            fn (str): Filename to save the data to.
         """
-        fn = fn.replace(".pth", ".json")
+        fn = f"{fn}.pth"
         folder = os.path.dirname(fn)
         if folder and not os.path.exists(folder):
             os.makedirs(folder)
-
-        fn = f"{fn}" if fn else "data"
-        table = json.load(open(fn, "r")) if os.path.exists(fn) else []
-
-        # Check if chi already exists and overwrite
-        chi_exists = False
-        for entry in table:
-            if entry["chi"] == self.args["chi"]:
-                entry["energies"] = self.energies
-                chi_exists = True
-                break
-
-        if not chi_exists:
-            table.append({"chi": self.args["chi"], "energies": self.energies})
-
-        json.dump(table, open(fn, "w"), indent=4)
+        torch.save(self.ipeps, fn)
         print(f"[green bold] \nData saved to {fn}")

--- a/src/pepsflow/iPEPS/converger.py
+++ b/src/pepsflow/iPEPS/converger.py
@@ -2,7 +2,7 @@ from pepsflow.iPEPS.iPEPS import iPEPS
 
 import torch
 import os
-from rich.progress import Progress, TextColumn, BarColumn, MofNCompleteColumn, TimeElapsedColumn
+from rich.progress import Progress, TaskID
 from rich import print
 
 
@@ -18,30 +18,14 @@ class Converger:
     def __init__(self, ipeps: iPEPS, args: dict):
         self.ipeps = iPEPS(args, ipeps)
 
-        self.progress = Progress(
-            TextColumn("[progress.description]{task.description}"),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TextColumn("•"),
-            TimeElapsedColumn(),
-        )
-        self.task = self.progress.add_task(
-            f"[blue bold]CTM steps (χ = {args['chi']})", total=args["Niter"], start=False
-        )
-
-    def exe(self):
+    def exe(self) -> None:
         """
         Compute the energy if a converged iPEPS state for a given bond dimension using the CTMRG
         algorithm. This method can only be called after reading the data.
         """
-        Niter = self.ipeps.args["Niter"]
-        self.ipeps.args["Niter"] = 1
-        with self.progress:
-            for _ in range(Niter):
-                E, C, T = self.ipeps.forward()
-                self.ipeps.add_data(E, C, T)
-                self.progress.update(self.task, advance=1)
+        with torch.no_grad():
+            E, C, T = self.ipeps.forward()
+        self.ipeps.add_data(E, C, T)
 
     def write(self, fn: str) -> None:
         """

--- a/src/pepsflow/iPEPS/converger.py
+++ b/src/pepsflow/iPEPS/converger.py
@@ -2,7 +2,6 @@ from pepsflow.iPEPS.iPEPS import iPEPS
 
 import torch
 import os
-from rich.progress import Progress, TaskID
 from rich import print
 
 

--- a/src/pepsflow/iPEPS/iPEPS.py
+++ b/src/pepsflow/iPEPS/iPEPS.py
@@ -1,7 +1,7 @@
 import torch
 
 from pepsflow.models.CTM_alg import CtmAlg
-from pepsflow.models.tensors import Methods
+from pepsflow.models.tensors import Methods, Tensors
 from pepsflow.models.observables import Observables
 
 
@@ -10,126 +10,91 @@ class iPEPS(torch.nn.Module):
     Class implementing an infinite Projected Entangled Pair State (iPEPS) tensor network.
 
     Args:
-        chi (int): Bond dimension of the edge and corner tensors.
-        lam (float): Regularization parameter for the iPEPS tensor.
-        H (torch.Tensor): Hamiltonian operator for the system.
-        map (torch.Tensor): indices of the parameters to map to the iPEPS tensor.
-        checkpoints (dict): Dictionary containing the corner and edge tensors and the parameters.
-        losses (list): List of losses.
-        epoch (int): Current epoch.
-        perturbation (float): Perturbation value for the parameters.
+        args (dict): Dictionary containing the arguments for the iPEPS model.
+        start_ipeps (dict): iPEPS tensor network to start from.
     """
 
     def __init__(
         self,
-        chi: int,
-        split: bool,
-        lam: float,
-        H: torch.Tensor,
-        map: torch.Tensor,
-        checkpoints: dict[list, list, list],  # {"C": [], "T": [], "params": []}
-        losses: list,
-        epoch: int,
-        perturbation: float,
-        norms: list,
+        args: dict,
+        initial_ipeps: "iPEPS" = None,
     ):
         super(iPEPS, self).__init__()
-        self.chi = chi
-        self.split = split
-        self.lam = lam
-        self.H = H
-        self.map = map
-        self.checkpoints = checkpoints
-        self.losses = losses[: epoch + 1] if epoch != -1 else losses
-        self.gradient_norms = norms
-        params = Methods.perturb(checkpoints["params"][epoch], perturbation)
+        self.args = args
+        self.initial_ipeps = initial_ipeps
+        self._setup_random() if initial_ipeps is None else self._setup_from_initial_ipeps()
+        self.C, self.T = None, None
+        self.data: dict[list, list, list, list, list]
+
+    def _setup_from_initial_ipeps(self) -> None:
+        """
+        Setup the iPEPS tensor network from the initial data.
+        """
+        self.data = {}
+        epoch = self.args["start_epoch"]
+        for key in ["params", "losses", "norms", "C", "T"]:
+            self.data[key] = self.initial_ipeps.data[key][: epoch + 1]
+
+        params = Methods.perturb(self.data["params"][epoch], self.args["perturbation"])
+        self.map = self.initial_ipeps.map
         self.params = torch.nn.Parameter(params)
-        self.C = checkpoints["C"][epoch]
-        self.T = checkpoints["T"][epoch]
+        self.H = self.initial_ipeps.H
 
-    def add_checkpoint(self, C: torch.Tensor, T: torch.Tensor) -> None:
+    def _setup_random(self) -> None:
         """
-        Add a checkpoint to the dictionary of checkpoints.
+        Setup the iPEPS tensor network with random parameters.
+        """
+        A = Tensors.A_random_symmetric(self.args["D"])
+        params, map = torch.unique(A, return_inverse=True)
+        self.data = {"C": [], "T": [], "params": [], "losses": [], "norms": []}
+        self.params = torch.nn.Parameter(params)
+        self.map = map
+        self.H = Tensors.Hamiltonian(self.args["model"], lam=self.args["lam"])
 
-        Args:
-            C (torch.Tensor): Corner tensor.
-            T (torch.Tensor): Edge tensor.
-            params (torch.Tensor): Parameters.
+    def add_data(self, loss: torch.Tensor, C: torch.Tensor, T: torch.Tensor) -> None:
         """
-        self.checkpoints["C"].append(C.clone().detach())
-        self.checkpoints["T"].append(T.clone().detach())
-        self.checkpoints["params"].append(self.params.clone().detach())
-
-    def add_loss(self, loss: torch.Tensor) -> None:
-        """
-        Add the loss to the list of losses.
+        Add the loss, corner, and edge tensors to the data dictionary.
 
         Args:
-            loss (torch.Tensor): Loss value.
+            loss (torch.Tensor): Loss value of the optimization step.
+            C (torch.Tensor): Corner tensor of the iPEPS tensor network.
+            T (torch.Tensor): Edge tensor of the iPEPS tensor network.
         """
-        self.losses.append(loss.item())
-
-    def add_gradient_norm(self) -> None:
-        """
-        Compute and add the gradient norm to the list of gradient norms.
-
-        Args:
-            norm (torch.Tensor): Gradient norm.
-        """
-        total_norm = torch.sqrt(sum(p.grad.detach().data.norm(2) ** 2 for p in self.parameters()))
-        self.gradient_norms.append(total_norm.item())
-
-    def set_edge_corner(self, C: torch.Tensor, T: torch.Tensor) -> None:
-        """
-        Set the corner and edge tensors of the iPEPS tensor network.
-
-        Args:
-            C (torch.Tensor): Corner tensor.
-            T (torch.Tensor): Edge tensor.
-        """
-        self.C = C.detach()
-        self.T = T.detach()
-
-    def get_edge_corner(self) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Get the corner and edge tensors of the iPEPS tensor network.
-
-        Returns:
-            tuple: Corner and edge tensors.
-        """
-        return self.C.clone().detach(), self.T.clone().detach()
+        self.data["losses"].append(loss)
+        self.data["params"].append(self.params.clone().detach())
+        norm = torch.sqrt(sum(p.grad.detach().data.norm(2) ** 2 for p in self.parameters() if p.grad is not None))
+        self.data["norms"].append(norm.item())
+        self.data["C"].append(C)
+        self.data["T"].append(T)
+        self.C, self.T = C, T
 
     def set_to_lowest_energy(self) -> None:
         """
         Set the iPEPS tensor network to the state with the lowest energy.
         """
-        i = self.losses.index(min(self.losses))
+        i = self.data["losses"].index(min(self.data["losses"]))
+        self.params = torch.nn.Parameter(self.data["params"][i])
+        for key in ["params", "losses", "norms", "C", "T"]:
+            self.data[key] = self.data[key][: i + 1]
 
-        self.set_edge_corner(self.checkpoints["C"][i], self.checkpoints["T"][i])
-        self.params = torch.nn.Parameter(self.checkpoints["params"][i])
-        self.losses = self.losses[: i + 1]
-        self.gradient_norms = self.gradient_norms[: i + 1]
-
-    def forward(self, C: torch.Tensor, T: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Compute the energy of the iPEPS tensor network by performing the following steps:
         1. Map the parameters to a symmetric rank-5 iPEPS tensor.
-        2. Construct the tensor network contraction a.
-        3. Execute the CTM (Corner Transfer Matrix) algorithm to compute the new corner (C) and edge (T) tensors.
-        4. Compute the loss as the energy expectation value using the Hamiltonian H, the symmetrized tensor,
+        2. Execute the CTM (Corner Transfer Matrix) algorithm to compute the corner (C) and edge (T) tensors.
+        3. Compute the loss as the energy expectation value using the Hamiltonian H, the symmetrized tensor,
            and the corner and edge tensors from the CTM algorithm.
 
         Returns:
             torch.Tensor: The loss, representing the energy expectation value, and the corner and edge tensors.
         """
-        # Map the parameters to a symmetric rank-5 iPEPS tensor
         Asymm = self.params[self.map]
+        Asymm = Asymm / Asymm.norm()
 
-        # Do one step of the CTM algorithm
-        alg = CtmAlg(Asymm, self.chi, C, T, self.split)
-        alg.exe()
+        if torch.isnan(self.params).any():
+            raise ValueError("NaN in the iPEPS tensor.")
 
-        # Compute the energy (loss) using the Hamiltonian, corner, and edge tensors
-        loss = Observables.E(Asymm, self.H, alg.C, alg.T)
+        alg = CtmAlg(Asymm, self.args["chi"], split=self.args["split"])
+        alg.exe(N=self.args["Niter"])
 
-        return loss, alg.C.detach(), alg.T.detach()
+        return Observables.E(Asymm, self.H, alg.C, alg.T), alg.C.detach(), alg.T.detach()

--- a/src/pepsflow/iPEPS/iPEPS.py
+++ b/src/pepsflow/iPEPS/iPEPS.py
@@ -62,8 +62,8 @@ class iPEPS(torch.nn.Module):
         """
         self.data["losses"].append(loss)
         self.data["params"].append(self.params.clone().detach())
-        norm = torch.sqrt(sum(p.grad.detach().data.norm(2) ** 2 for p in self.parameters() if p.grad is not None))
-        self.data["norms"].append(norm.item())
+        squared_norm = sum(p.data.norm(2) ** 2 for p in self.parameters() if p.grad is not None)
+        self.data["norms"].append(torch.sqrt(squared_norm) if isinstance(squared_norm, torch.Tensor) else squared_norm)
         self.data["C"].append(C)
         self.data["T"].append(T)
         self.C, self.T = C, T

--- a/src/pepsflow/iPEPS/reader.py
+++ b/src/pepsflow/iPEPS/reader.py
@@ -33,7 +33,7 @@ class iPEPSReader:
         Returns:
             list: List of losses.
         """
-        return self.iPEPS.data["losses"]
+        return [E.detach() for E in self.iPEPS.data["losses"]]
 
     def gradient_norms(self) -> list[float]:
         """
@@ -51,7 +51,7 @@ class iPEPSReader:
         Returns:
             torch.Tensor: iPEPS state
         """
-        return self.iPEPS.params[self.iPEPS.map]
+        return self.iPEPS.params.detach()
 
     def energy(self) -> float:
         """
@@ -60,7 +60,7 @@ class iPEPSReader:
         Returns:
             float: Energy of the iPEPS model.
         """
-        return self.iPEPS.data["losses"][-1]
+        return float(self.iPEPS.data["losses"][-1].detach())
 
     def magnetization(self) -> float:
         """

--- a/src/pepsflow/iPEPS/reader.py
+++ b/src/pepsflow/iPEPS/reader.py
@@ -1,5 +1,4 @@
 import torch
-import os
 
 from pepsflow.models.observables import Observables
 from pepsflow.iPEPS.iPEPS import iPEPS
@@ -14,8 +13,8 @@ class iPEPSReader:
     """
 
     def __init__(self, file: str):
-        self.iPEPS: iPEPS = torch.load(file, weights_only=False)
-        self.file = file
+        self.file = f"{file}.pth" if not file.endswith(".pth") else file
+        self.iPEPS: iPEPS = torch.load(self.file, weights_only=False)
         self.iPEPS.eval()
 
     def lam(self) -> float:
@@ -25,7 +24,7 @@ class iPEPSReader:
         Returns:
             float: Lambda value.
         """
-        return self.iPEPS.lam
+        return self.iPEPS.args["lam"]
 
     def losses(self) -> list[float]:
         """
@@ -34,7 +33,7 @@ class iPEPSReader:
         Returns:
             list: List of losses.
         """
-        return self.iPEPS.losses
+        return self.iPEPS.data["losses"]
 
     def gradient_norms(self) -> list[float]:
         """
@@ -43,7 +42,7 @@ class iPEPSReader:
         Returns:
             list: List of gradient norms.
         """
-        return self.iPEPS.gradient_norms
+        return self.iPEPS.data["norms"]
 
     def iPEPS_state(self) -> torch.Tensor:
         """
@@ -61,7 +60,7 @@ class iPEPSReader:
         Returns:
             float: Energy of the iPEPS model.
         """
-        return self.iPEPS.losses[-1]
+        return self.iPEPS.data["losses"][-1]
 
     def magnetization(self) -> float:
         """

--- a/src/pepsflow/iPEPS/trainer.py
+++ b/src/pepsflow/iPEPS/trainer.py
@@ -1,11 +1,9 @@
-from pepsflow.models.tensors import Tensors
 from pepsflow.iPEPS.iPEPS import iPEPS
-from pepsflow.models.CTM_alg import CtmAlg
 from pepsflow.models.optimizers import Optimizer
 
 import torch
 import os
-from rich.progress import Progress, TextColumn, BarColumn, MofNCompleteColumn, TimeElapsedColumn
+from rich.progress import Progress, TaskID
 from rich import print
 
 
@@ -15,154 +13,67 @@ class Trainer:
     values of lambda.
 
     Args:
-        args (dict): Dictionary containing the arguments for training the iPEPS model.
+        opt_args (dict): Dictionary containing the arguments for the optimization process.
+        ipeps_args (dict): Dictionary containing the arguments for the iPEPS model.
     """
 
-    def __init__(self, args: dict):
+    def __init__(self, ipeps: iPEPS, args: dict):
         torch.set_num_threads(args["threads"])
         torch.random.manual_seed(args["seed"]) if args["seed"] else None
         self.args = args
-        self.data, self.data_prev = None, None
-
-        self.progress = Progress(
-            TextColumn("[progress.description]{task.description}"),
-            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TextColumn("•"),
-            TimeElapsedColumn(),
-        )
-        param = self.args["var_param"]
-        self.warmup_task = self.progress.add_task(
-            f"[blue bold]CTM steps ({param} = {self.args[param]})",
-            total=self.args["warmup_steps"] * self.args["runs"],
-            start=False,
-            visible=False,
-        )
-        self.training_task = self.progress.add_task(
-            f"[blue bold]Training iPEPS ({param} = {self.args[param]})",
-            total=self.args["runs"] * self.args["epochs"],
-            start=False,
+        self.ipeps = ipeps
+        ls = "strong_wolfe" if self.args["line_search"] else None
+        self.opt = Optimizer(
+            self.args["optimizer"], self.ipeps.parameters(), lr=self.args["learning_rate"], line_search_fn=ls
         )
 
-    def read(self, fn: str) -> None:
+    def exe(self, progress: Progress, task: TaskID) -> None:
         """
-        Read the data from a torch .pth file.
+        Optimize the iPEPS model using the CTM algorithm and the given optimizer.
 
         Args:
-            fn (str): Filename to read the data from, without file extension. Has to be a .pth file.
+            progress (Progress): Rich Progress object to track the progress of the optimization.
+            task (TaskID): Task ID of the progress object.
         """
-        self.data_prev: iPEPS = torch.load(fn, weights_only=False)
-
-    def exe(self) -> None:
-        """
-        Execute the training of the iPEPS model for different values of lambda.
-        """
-        best_model = None
-
-        with self.progress:
-            for _ in range(self.args["runs"]):
-                model = self._train_model()
-
-                # Update the best model based on the lowest energy
-                if not best_model or model.losses[-1] < best_model.losses[-1]:
-                    best_model = model
-
-        self.data = best_model
-
-    def _train_model(self) -> iPEPS:
-        """
-        Train the iPEPS model for the given parameters.
-        """
-
-        checkpoint, map, losses, epoch, norms = self._get_checkpoint()
-
-        H = (
-            Tensors.H_Heisenberg(self.args["lam"])
-            if self.args["model"] == "Heisenberg"
-            else Tensors.H_Ising(self.args["lam"])
-        )
-        chi, lam, per, split = self.args["chi"], self.args["lam"], self.args["perturbation"], self.args["split"]
-        model = iPEPS(chi, split, lam, H, map, checkpoint, losses, epoch, per, norms)
-        ls = "strong_wolfe" if self.args["line_search"] else None
-        optimizer = Optimizer(
-            self.args["optimizer"],
-            model.parameters(),
-            lr=self.args["learning_rate"],
-            line_search_fn=ls,
-        )
-
-        C, T = model.get_edge_corner()
 
         def train() -> torch.Tensor:
             """
             Do one step in the CTM algorithm, compute the loss, and do the
             backward pass where the gradients are computed.
             """
-            nonlocal C, T
-            optimizer.zero_grad()
-            loss, C, T = model.forward(C, T)
+            self.opt.zero_grad()
+            loss, _, _ = self.ipeps.forward()
             loss.backward()
             return loss
 
-        self.progress.start_task(self.training_task)
-        for _ in range(self.args["epochs"]):
-            loss = optimizer.step(train)
+        with progress:
+            progress.start_task(task)
+            for epoch in range(self.args["epochs"]):
+                try:
+                    self.opt.step(train)
 
-            # Save intermediate results
-            model.add_checkpoint(C, T)
-            model.add_loss(loss)
-            model.add_gradient_norm()
+                    with torch.no_grad():
+                        loss, C, T = self.ipeps.forward()
+                        print(f"epoch, E: {epoch, loss.item()}")
 
-            # Update the progress bar
-            self.progress.update(self.training_task, advance=1)
+                    # Save intermediate results
+                    self.ipeps.add_data(loss, C, T)
+                    progress.update(task, advance=1)
 
-        # Save the final corner and edge tensors
-        model.set_edge_corner(C, T)
-
-        return model
-
-    def _get_checkpoint(self) -> dict:
-        """
-        Get the checkpoint dictionary, the map of the parameters for the iPEPS model and the losses.
-        This is either initialized from the given data or generated randomly. The checkpoint
-        dictionary contains the corner and edge tensors and the parameters.
-
-        Returns:
-            tuple: Checkpoint dictionary, the map of the parameters, losses, the current epoch, and
-            the gradient norms.
-        """
-        # Use the corresponding state from the given data as the initial state.
-        if self.data_prev:
-            checkpoint = self.data_prev.checkpoints
-            losses = self.data_prev.losses
-            gradient_norms = self.data_prev.gradient_norms
-            map = self.data_prev.map
-            epoch = self.args["start_epoch"]
-
-        # Generate a random symmetric A tensor and do CTM warmup steps
-        else:
-            A = Tensors.A_random_symmetric(self.args["D"])
-            params, map = torch.unique(A, return_inverse=True)
-            alg = CtmAlg(A, chi=self.args["chi"], split=self.args["split"])
-            self.progress.tasks[self.warmup_task].visible = True
-            alg.exe(N=self.args["warmup_steps"], progress=self.progress, task=self.warmup_task)
-            C, T = alg.C, alg.T
-            checkpoint = {"C": [C], "T": [T], "params": [params]}
-            losses, gradient_norms = [], []
-            epoch = -1
-
-        return checkpoint, map, losses, epoch, gradient_norms
+                except ValueError:
+                    print("[red bold] NaN in iPEPS tensor detected. Saving and quiting training...")
+                    break
 
     def write(self, fn: str) -> None:
         """
         Save the collected data to a torch .pth file.
 
         Args:
-            fn (str): Filename to save the data to. Has to be a .pth file.
+            fn (str): Filename to save the data to.
         """
+        fn = f"{fn}.pth"
         folder = os.path.dirname(fn)
         if folder and not os.path.exists(folder):
             os.makedirs(folder)
-        torch.save(self.data, fn)
+        torch.save(self.ipeps, fn)
         print(f"[green bold] \nData saved to {fn}")

--- a/src/pepsflow/iPEPS/trainer.py
+++ b/src/pepsflow/iPEPS/trainer.py
@@ -27,7 +27,7 @@ class Trainer:
             self.args["optimizer"], self.ipeps.parameters(), lr=self.args["learning_rate"], line_search_fn=ls
         )
 
-    def exe(self, progress: Progress, task: TaskID) -> None:
+    def exe(self, progress: Progress = None, task: TaskID = None) -> None:
         """
         Optimize the iPEPS model using the CTM algorithm and the given optimizer.
 
@@ -47,7 +47,7 @@ class Trainer:
             return loss
 
         with progress:
-            progress.start_task(task)
+            progress.start_task(task) if progress else None
             for epoch in range(self.args["epochs"]):
                 try:
                     self.opt.step(train)
@@ -58,7 +58,7 @@ class Trainer:
 
                     # Save intermediate results
                     self.ipeps.add_data(loss, C, T)
-                    progress.update(task, advance=1)
+                    progress.update(task, advance=1) if progress else None
 
                 except ValueError:
                     print("[red bold] NaN in iPEPS tensor detected. Saving and quiting training...")

--- a/src/pepsflow/pepsflow.cfg
+++ b/src/pepsflow/pepsflow.cfg
@@ -1,27 +1,28 @@
 [parameters]
 
 [parameters.ipeps]
-model = 'Ising'
-chi = 16
-D = 2
-lam = [2.7, 2.75, 2.8, 2.85, 2.9, 2.95, 3.0, 3.05, 3.1, 3.15, 3.2, 3.25, 3.3]
-Niter = 50
+model = 'Heisenberg'
+chi = [12, 13, 14, 15, 16, 17, 18, 20, 22, 25, 29, 33, 40, 50, 66, 100, 200]
+D = 3
+lam = 1
+Niter = 100
 split = False
 perturbation = 0.0
-start_epoch = 29
+start_epoch = 35
 
 [parameters.optimization]
 warmup_steps = 200
 optimizer = 'lbfgs'
 line_search = True
 learning_rate = 0.1
-epochs = 30
+epochs = 10
 gpu = False
 threads = 1
 seed = 1.0
+log = False
 
 [parameters.folders]
 data = 'data'
-read = None
-write = 'test'
+read = 'J2_1'
+write = 'J2_1'
 

--- a/src/pepsflow/pepsflow.cfg
+++ b/src/pepsflow/pepsflow.cfg
@@ -1,20 +1,27 @@
-[PARAMETERS]
-model = Heisenberg
-chi = 68
-D = 3
-lam = 1
-warmup_steps = 50
-optimizer = ['adam', 'lbfgs']
-line_search = False
-runs = 1
-learning_rate = 0.1
-epochs = 200
+[parameters]
+
+[parameters.ipeps]
+model = 'Ising'
+chi = 16
+D = 2
+lam = [2.7, 2.75, 2.8, 2.85, 2.9, 2.95, 3.0, 3.05, 3.1, 3.15, 3.2, 3.25, 3.3]
+Niter = 50
+split = False
 perturbation = 0.0
+start_epoch = 29
+
+[parameters.optimization]
+warmup_steps = 200
+optimizer = 'lbfgs'
+line_search = True
+learning_rate = 0.1
+epochs = 30
 gpu = False
 threads = 1
-write_folder = optimizers
-read_folder = None
-start_epoch = -1
-split = False
-seed = 2.0
+seed = 1.0
+
+[parameters.folders]
+data = 'data'
+read = None
+write = 'test'
 

--- a/src/pepsflow/pepsflow.py
+++ b/src/pepsflow/pepsflow.py
@@ -121,13 +121,12 @@ def converge(var_param, value: float, args: dict, read_fn: str):
         raise KeyError("Only chi as variational parameter is supported for convergence.")
 
     folders, ipeps_params = args["parameters.folders"], args["parameters.ipeps"]
-    task = progress.add_task(f"[blue bold]CTM steps (χ = {value})", total=ipeps_params["Niter"], start=False)
 
     ipeps = iPEPSReader(path(folders["read"], read_fn)).iPEPS
 
     # Execute the convergence and write the data to a file
     conv = Converger(ipeps, ipeps_params)
-    conv.exe(progress, task)
+    conv.exe()
     conv.write(path(folders["write"], write_fn))
 
 

--- a/src/pepsflow/pepsflow.py
+++ b/src/pepsflow/pepsflow.py
@@ -2,9 +2,12 @@ import configparser
 import multiprocessing as mp
 import os
 import ast
+from rich.progress import Progress, TextColumn, SpinnerColumn, MofNCompleteColumn, TimeElapsedColumn, BarColumn
 
 from pepsflow.iPEPS.trainer import Trainer
 from pepsflow.iPEPS.converger import Converger
+from pepsflow.iPEPS.iPEPS import iPEPS
+from pepsflow.iPEPS.reader import iPEPSReader
 
 
 def path(folder: str, file: str) -> str:
@@ -21,61 +24,85 @@ def path(folder: str, file: str) -> str:
     return os.path.join("data", folder, file)
 
 
-def read_config() -> dict:
+def read_config() -> tuple[dict, tuple[str, str]]:
     """
     Read the parameters from the configuration file.
 
     Returns:
         dict: Dictionary containing the parameters.
+        tuple: Tuple containing the section and key of the varying parameter.
     """
     parser = configparser.ConfigParser()
     parser.optionxform = str  # Preserve the case of the keys
     parser.read("src/pepsflow/pepsflow.cfg")
-    args = dict(parser["PARAMETERS"])
-    args["var_param"] = None
 
-    for key, value in args.items():
+    var_param = None
+    args = {section: {} for section in parser.sections()}
+    for section in args.keys():
+        for key, value in parser.items(section):
+            try:
+                args[section][key] = ast.literal_eval(value)
+                args[section][key] = None if value == "None" else args[section][key]
 
-        try:
-            args[key] = ast.literal_eval(value)
-            args[key] = None if value == "None" else args[key]
+                if isinstance(args[section][key], list):
+                    if var_param:
+                        raise KeyError("Only one varying parameter is allowed.")
+                    var_param = (section, key)
 
-            if type(args[key]) == list:
-                if args["var_param"] is None:
-                    args["var_param"] = key
-                else:
-                    raise KeyError("Only one varying parameter is allowed.")
+            # If the value is no type and should be a string
+            except ValueError:
+                pass
 
-        except ValueError:
-            pass
-
-    if args["var_param"] is None:
+    if var_param is None:
         raise KeyError("No variational parameter found.")
 
-    return args
+    return args, var_param
 
 
-def optimize(value: float, args: dict):
+def optimize(var_param: tuple[str, str], value: float, args: dict):
     """
     Optimize the iPEPS model for a single value the variational parameter.
 
     Args:
+        var_param (tuple): Section and key of the variational parameter.
         value (float): Value of the variational parameter.
-        param (str): Name of the variational parameter.
-        args (dict): Arguments for the optimization.
+        args (dict): folder, ipeps, and optimization parameters.
     """
+
     # Set the value of the variational parameter
-    args[args["var_param"]] = value
-    fn = f"{args['var_param']}_{value}.pth"
+    section, key = var_param
+    args[section][key] = value
+    fn = f"{key}_{value}"
 
-    trainer = Trainer(args)
-    if args["read_folder"]:
-        trainer.read(path(args["read_folder"], fn))
-    trainer.exe()
-    trainer.write(path(args["write_folder"], fn))
+    folders = args["parameters.folders"]
+    ipeps_params = args["parameters.ipeps"]
+    opt_params = args["parameters.optimization"]
+
+    # Initialize the progress bar
+    progress = Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TextColumn("•"),
+        TimeElapsedColumn(),
+    )
+    task = progress.add_task(f"[blue bold]Training iPEPS ({key} = {value})", total=opt_params["epochs"], start=False)
+
+    # Read the iPEPS model from a file if specified
+    if folders["read"]:
+        ipeps = iPEPSReader(path(folders["read"], fn)).iPEPS
+        ipeps = iPEPS(args=ipeps_params, initial_ipeps=ipeps)
+    else:
+        ipeps = iPEPS(ipeps_params)
+
+    # Execute the optimization and write the iPEPS model to a file
+    trainer = Trainer(ipeps, opt_params)
+    trainer.exe(progress, task)
+    trainer.write(path(folders["write"], fn))
 
 
-def converge(value: float, args: dict, read_fn: str):
+def converge(var_param, value: float, args: dict, read_fn: str):
     """
     Compute the energy if a converged iPEPS state for a given bond dimension using the CTMRG
     algorithm.
@@ -86,25 +113,34 @@ def converge(value: float, args: dict, read_fn: str):
         read_fn (str): Filename of the data file to read from
     """
     # Set the value of the variational parameter
-    if args["var_param"] == "chi":
-        args[args["var_param"]] = value
-        fn = f"{args['var_param']}_{value}.pth"
+    if var_param == "chi":
+        section, key = var_param
+        args[section][key] = value
+        write_fn = f"{key}_{value}"
     else:
         raise KeyError("Only chi as variational parameter is supported for convergence.")
 
-    conv = Converger(args)
-    conv.read(path(args["read_folder"], read_fn))
+    folders, ipeps_params = args["parameters.folders"], args["parameters.ipeps"]
+
+    ipeps = iPEPSReader(path(folders["read"], read_fn)).iPEPS
+
+    # Execute the convergence and write the data to a file
+    conv = Converger(ipeps, ipeps_params)
     conv.exe()
-    conv.write(path(args["write_folder"], fn))
+    conv.write(path(folders["write"], write_fn))
 
 
 def optimize_parallel():
     """
     Optimize the iPEPS model for a list of values of the variational parameter.
     """
-    args = read_config()
-    with mp.Pool(processes=len(args[args["var_param"]])) as pool:
-        pool.starmap(optimize, [(value, args.copy()) for value in args[args["var_param"]]])
+    args, var_param = read_config()
+    section, key = var_param
+    var_param_values = args[section][key]
+    num_processes = len(var_param_values)
+
+    with mp.Pool(num_processes) as pool:
+        pool.starmap(optimize, [(var_param, value, args.copy()) for value in var_param_values])
 
 
 def converge_parallel(read_fn: str):
@@ -115,6 +151,10 @@ def converge_parallel(read_fn: str):
     Args:
         read_fn (str): Filename of the data file to read from.
     """
-    args = read_config()
-    with mp.Pool(processes=len(args[args["var_param"]])) as pool:
-        pool.starmap(converge, [(value, args.copy(), read_fn) for value in args[args["var_param"]]])
+    args, var_param = read_config()
+    section, key = var_param
+    var_param_values = args[section][key]
+    num_processes = len(var_param_values)
+
+    with mp.Pool(num_processes) as pool:
+        pool.starmap(converge, [(value, args.copy(), read_fn) for value in var_param_values])


### PR DESCRIPTION
Changes include:
 - Divided the parameter in the .`cfg` file in 3 sections (`"ipeps"`, `"optimization"`, `"folders"`)
 - Trainer/Converger now only take an instance of iPEPS, and `"optimization"` and `"ipeps"` respectively.
 - Data of Converger is saved as a new iPEPS file with the corresponding `chi` in the filename.
 -  `Niter` option is added to the `.cfg` file for the number of CTM steps in `iPEPS.forward`
 - `cli` is updated to handle the sections in the `.cfg` file and the new `Niter` option.
 -  Added J1/J2 model
 - Previously called `checkpoint` dictionary (attribute of `iPEPS`) is now called `data` and includes `losses` and `norms`.

These changes have fixed the following issues:
- #88 
- #93 
- #80 
- #64 
- #55
